### PR TITLE
Add header and license notice on all files

### DIFF
--- a/src/FEM/DtN_application.m
+++ b/src/FEM/DtN_application.m
@@ -1,3 +1,38 @@
+% DtN_application.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 A(nb_dof_FEM+size_info_vector_R*nb_R+size_info_vector_T*nb_T,nb_dof_FEM+size_info_vector_R*nb_R+size_info_vector_T*nb_T)=0;
 F(nb_dof_FEM+size_info_vector_R*nb_R+size_info_vector_T*nb_T)=0;
 

--- a/src/FEM/DtN_application2.m
+++ b/src/FEM/DtN_application2.m
@@ -1,3 +1,38 @@
+% DtN_application2.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 if (nb_R+nb_T)>0
         A_2(nb_dof_FEM+nb_R+nb_T,nb_dof_FEM+nb_R+nb_T)=0;
         F_2(nb_dof_FEM+nb_R+nb_T,1)=0;

--- a/src/FEM/DtN_application_JAP.m
+++ b/src/FEM/DtN_application_JAP.m
@@ -1,3 +1,38 @@
+% DtN_application_JAP.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 A(nb_dof_FEM+size_info_vector_R*nb_R+size_info_vector_T*nb_T,nb_dof_FEM+size_info_vector_R*nb_R+size_info_vector_T*nb_T)=0;
 F(nb_dof_FEM+2*nb_R+nb_T)=0;
 

--- a/src/FEM/EF_TR6_global_build.m
+++ b/src/FEM/EF_TR6_global_build.m
@@ -1,3 +1,38 @@
+% EF_TR6_global_build.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 create_temporary_FEM_matrices
 
 for ie=1:nb_elements

--- a/src/FEM/FEM_resolution.m
+++ b/src/FEM/FEM_resolution.m
@@ -1,3 +1,38 @@
+% FEM_resolution.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 tic
 for i_f=1:abs(nb_frequencies)
     FEM_progress=100*i_f/abs(nb_frequencies)

--- a/src/FEM/TR6_FSI.m
+++ b/src/FEM/TR6_FSI.m
@@ -1,1 +1,36 @@
+% TR6_FSI.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function FSIe = TR6_FSI(a1,a2)    J=norm(a2-a1)/2.00D+00;            npg=4;    ksi_g(1)= 0.339981043584856;    ksi_g(2)=-0.339981043584856;    ksi_g(3)= 0.861136311594053;    ksi_g(4)=-0.861136311594053;          p_g(1)=   0.652145154862546;    p_g(2)=   0.652145154862546;    p_g(3)=   0.347854845137454;    p_g(4)=   0.347854845137454;        FSIe=0.00D+00;	        for ipg=1:npg        	ksi=ksi_g(ipg);    	    	N(1,1)=-(1-ksi)*ksi/2;    	N(2,1)= (1+ksi)*ksi/2;    	N(3,1)= (1-ksi)*(1+ksi);    	    	FSIe=FSIe+N*N'*J*p_g(ipg);     end    

--- a/src/FEM/TR6_PW.m
+++ b/src/FEM/TR6_PW.m
@@ -1,1 +1,36 @@
+% TR6_PW.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function F = TR6_PW(longueur,k,a)n_pg=4;points_gauss(1)= 0.339981043584856;points_gauss(2)=-0.339981043584856;points_gauss(3)= 0.861136311594053;points_gauss(4)=-0.861136311594053;weight_gauss(1)=0.652145154862546;weight_gauss(2)=0.652145154862546;weight_gauss(3)=0.347854845137454;weight_gauss(4)=0.347854845137454;F=zeros(3,1);for i_pg=1:n_pg	xi=points_gauss(i_pg);		F(1)=F(1)+(-(1-xi)*xi/2)  *exp(-1i*k*(longueur*xi/2))*(weight_gauss(i_pg));	F(2)=F(2)+( (1+xi)*xi/2)  *exp(-1i*k*(longueur*xi/2))*(weight_gauss(i_pg));	F(3)=F(3)+( (1-xi)*(1+xi))*exp(-1i*k*(longueur*xi/2))*(weight_gauss(i_pg));endF=F*(longueur/2)*exp(-j*k*(a+longueur/2));       end

--- a/src/FEM/TR6_elas.m
+++ b/src/FEM/TR6_elas.m
@@ -1,1 +1,36 @@
+% TR6_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [vm,vk0,vk1] = TR6_elas(coord_e)% Gauss Points Data%------------------------------npg=6;a=0.445948490915965;b=0.091576213509771;P1=0.111690794839005;P2=0.054975871827661;ksig=[  a, a;    1-2*a, a;    a,   1-2*a;    b, b;    1-2*b, b;    b, 1-2*b];w_g=[P1,P1,P1,P2,P2,P2];% Matrices initialization%-----------------------vk0 = zeros(12,12);vk1 = zeros(12,12);vm=zeros(12,12);D0=[1 1 0;1 1 0; 0 0 0];D1=[0 -2 0;-2 0 0; 0 0 1];% Loop on Gauss Points%------------------for ipg=1:npg,    ksi=ksig(ipg,1);    eta=ksig(ipg,2);    lambda=1-ksi-eta;        Phi =  [ -lambda*(1-2*lambda)  4*ksi*lambda  -ksi*(1-2*ksi) 4*ksi*eta -eta*(1-2*eta) 4*eta*lambda];    dPhi  = [ 1-4*lambda 4*(lambda-ksi) -1+4*ksi 4*eta 0 -4*eta; ...             1-4*lambda -4*ksi 0 4*ksi -1+4*eta 4*(lambda-eta)];    J = dPhi*coord_e';        weight = w_g(ipg) * det(J);        vB =J\dPhi;    eps=[vB(1,1) 0 vB(1,2) 0 vB(1,3) 0 vB(1,4) 0 vB(1,5) 0 vB(1,6) 0;           0 vB(2,1) 0 vB(2,2) 0 vB(2,3) 0 vB(2,4) 0 vB(2,5) 0 vB(2,6);           vB(2,1) vB(1,1) vB(2,2) vB(1,2) vB(2,3) vB(1,3) vB(2,4) vB(1,4) vB(2,5) vB(1,5) vB(2,6) vB(1,6)];    Phi_u=[Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6) 0;        0 Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6)];        vk0= vk0 +  eps'*D0*eps *weight;    vk1= vk1 +  eps'*D1*eps *weight;    vm = vm +  Phi_u'*Phi_u * weight;end;   % fin de boucle sur les points de gauss.

--- a/src/FEM/TR6_fluid.m
+++ b/src/FEM/TR6_fluid.m
@@ -1,1 +1,36 @@
+% TR6_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [vh,vq] = TR6_fluid(coord_e)% Gauss Points Data%------------------------------npg=6;a=0.445948490915965;b=0.091576213509771;P1=0.111690794839005;P2=0.054975871827661;ksig=[  a, a;    1-2*a, a;    a,   1-2*a;    b, b;    1-2*b, b;    b, 1-2*b];w_g=[P1,P1,P1,P2,P2,P2];% Matrices initialization%-----------------------vh=zeros(6,6);vq=zeros(6,6);% Loop on Gauss Points%------------------for ipg=1:npg,    ksi=ksig(ipg,1);    eta=ksig(ipg,2);    lambda=1-ksi-eta;        Phi =  [ -lambda*(1-2*lambda)  4*ksi*lambda  -ksi*(1-2*ksi) 4*ksi*eta -eta*(1-2*eta) 4*eta*lambda];    dPhi  = [ 1-4*lambda 4*(lambda-ksi) -1+4*ksi 4*eta 0 -4*eta; ...             1-4*lambda -4*ksi 0 4*ksi -1+4*eta 4*(lambda-eta)];    J = dPhi*coord_e';        weight = w_g(ipg) * det(J);        vB =J\dPhi;       Gd=[vB(1,1) vB(1,2) vB(1,3) vB(1,4) vB(1,5) vB(1,6);           vB(2,1) vB(2,2) vB(2,3) vB(2,4) vB(2,5) vB(2,6)];    vh=vh+Gd'*Gd*weight;    vq=vq+Phi'*Phi*weight;end;  

--- a/src/FEM/TR6_pem01.m
+++ b/src/FEM/TR6_pem01.m
@@ -1,1 +1,36 @@
+% TR6_pem01.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [vm,vk0,vk1,vc,vcp,vh,vq] = TR6_pem01(coord_e)% Gauss Points Data%------------------------------npg=6;a=0.445948490915965;b=0.091576213509771;P1=0.111690794839005;P2=0.054975871827661;ksig=[  a, a;    1-2*a, a;    a,   1-2*a;    b, b;    1-2*b, b;    b, 1-2*b];w_g=[P1,P1,P1,P2,P2,P2];% Matrices initialization%-----------------------vk0 = zeros(12,12);vk1 = zeros(12,12);vm=zeros(12,12);vc=zeros(12,6);vcp=zeros(12,6);vh=zeros(6,6);vq=zeros(6,6);D0=[1 1 0;1 1 0; 0 0 0];D1=[0 -2 0;-2 0 0; 0 0 1];% Loop on Gauss Points%------------------for ipg=1:npg,    ksi=ksig(ipg,1);    eta=ksig(ipg,2);    lambda=1-ksi-eta;        Phi =  [ -lambda*(1-2*lambda)  4*ksi*lambda  -ksi*(1-2*ksi) 4*ksi*eta -eta*(1-2*eta) 4*eta*lambda];    dPhi  = [ 1-4*lambda 4*(lambda-ksi) -1+4*ksi 4*eta 0 -4*eta; ...             1-4*lambda -4*ksi 0 4*ksi -1+4*eta 4*(lambda-eta)];    J = dPhi*coord_e';        weight = w_g(ipg) * det(J);        vB =J\dPhi;    eps=[vB(1,1) 0 vB(1,2) 0 vB(1,3) 0 vB(1,4) 0 vB(1,5) 0 vB(1,6) 0;           0 vB(2,1) 0 vB(2,2) 0 vB(2,3) 0 vB(2,4) 0 vB(2,5) 0 vB(2,6);           vB(2,1) vB(1,1) vB(2,2) vB(1,2) vB(2,3) vB(1,3) vB(2,4) vB(1,4) vB(2,5) vB(1,5) vB(2,6) vB(1,6)];    Gd=[vB(1,1) vB(1,2) vB(1,3) vB(1,4) vB(1,5) vB(1,6);           vB(2,1) vB(2,2) vB(2,3) vB(2,4) vB(2,5) vB(2,6)];    Div=[vB(1,1) vB(2,1) vB(1,2) vB(2,2) vB(1,3) vB(2,3) vB(1,4) vB(2,4) vB(1,5) vB(2,5) vB(1,6) vB(2,6)];    Phi_u=[Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6) 0;        0 Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6)];        vk0= vk0 +  eps'*D0*eps *weight;    vk1= vk1 +  eps'*D1*eps *weight;    vm = vm +  Phi_u'*Phi_u * weight;    vc= vc+Phi_u'*Gd*weight;    vcp=vcp+Div'*Phi*weight;    vh=vh+Gd'*Gd*weight;    vq=vq+Phi'*Phi*weight;end;   

--- a/src/FEM/TR6_pem98.m
+++ b/src/FEM/TR6_pem98.m
@@ -1,1 +1,36 @@
+% TR6_pem98.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [vm,vk0,vk1,vc,vh,vq] = TR6_pem01(coord_e)% Gauss Points Data%------------------------------npg=6;a=0.445948490915965;b=0.091576213509771;P1=0.111690794839005;P2=0.054975871827661;ksig=[  a, a;    1-2*a, a;    a,   1-2*a;    b, b;    1-2*b, b;    b, 1-2*b];w_g=[P1,P1,P1,P2,P2,P2];% Matrices initialization%-----------------------vk0 = zeros(12,12);vk1 = zeros(12,12);vm=zeros(12,12);vc=zeros(12,6);vcp=zeros(12,6);vh=zeros(6,6);vq=zeros(6,6);D0=[1 1 0;1 1 0; 0 0 0];D1=[0 -2 0;-2 0 0; 0 0 1];% Loop on Gauss Points%------------------for ipg=1:npg,    ksi=ksig(ipg,1);    eta=ksig(ipg,2);    lambda=1-ksi-eta;        Phi =  [ -lambda*(1-2*lambda)  4*ksi*lambda  -ksi*(1-2*ksi) 4*ksi*eta -eta*(1-2*eta) 4*eta*lambda];    dPhi  = [ 1-4*lambda 4*(lambda-ksi) -1+4*ksi 4*eta 0 -4*eta; ...             1-4*lambda -4*ksi 0 4*ksi -1+4*eta 4*(lambda-eta)];    J = dPhi*coord_e';        weight = w_g(ipg) * det(J);        vB =J\dPhi;    eps=[vB(1,1) 0 vB(1,2) 0 vB(1,3) 0 vB(1,4) 0 vB(1,5) 0 vB(1,6) 0;           0 vB(2,1) 0 vB(2,2) 0 vB(2,3) 0 vB(2,4) 0 vB(2,5) 0 vB(2,6);           vB(2,1) vB(1,1) vB(2,2) vB(1,2) vB(2,3) vB(1,3) vB(2,4) vB(1,4) vB(2,5) vB(1,5) vB(2,6) vB(1,6)];    Gd=[vB(1,1) vB(1,2) vB(1,3) vB(1,4) vB(1,5) vB(1,6);           vB(2,1) vB(2,2) vB(2,3) vB(2,4) vB(2,5) vB(2,6)];    Phi_u=[Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6) 0;        0 Phi(1) 0 Phi(2) 0 Phi(3) 0 Phi(4) 0 Phi(5) 0 Phi(6)];        vk0= vk0 +  eps'*D0*eps *weight;    vk1= vk1 +  eps'*D1*eps *weight;    vm = vm +  Phi_u'*Phi_u * weight;    vc= vc+Phi_u'*Gd*weight;    vh=vh+Gd'*Gd*weight;    vq=vq+Phi'*Phi*weight;end;   

--- a/src/FEM/apply_FSI.m
+++ b/src/FEM/apply_FSI.m
@@ -1,3 +1,38 @@
+% apply_FSI.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 for ie=1:nb_interfaces
     
     x1=nodes(interfaces(ie,1),1);

--- a/src/FEM/clear_temporary_FEM_matrices.m
+++ b/src/FEM/clear_temporary_FEM_matrices.m
@@ -1,3 +1,38 @@
+% clear_temporary_FEM_matrices.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 clear i_k0_pem01;
 clear j_k0_pem01;
 clear v_k0_pem01;

--- a/src/FEM/create_temporary_FEM_matrices.m
+++ b/src/FEM/create_temporary_FEM_matrices.m
@@ -1,3 +1,38 @@
+% create_temporary_FEM_matrices.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 i_k0_pem01=zeros(1,nb_media.pem01);
 j_k0_pem01=zeros(1,nb_media.pem01);
 v_k0_pem01=zeros(1,nb_media.pem01);

--- a/src/FEM/discard_l1_temporary_FEM_matrices.m
+++ b/src/FEM/discard_l1_temporary_FEM_matrices.m
@@ -1,3 +1,38 @@
+% discard_l1_temporary_FEM_matrices.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 i_k0_pem01(1,:)=[];
 j_k0_pem01(1,:)=[];
 v_k0_pem01(1,:)=[];

--- a/src/FEM/excitation_10000.m
+++ b/src/FEM/excitation_10000.m
@@ -1,3 +1,38 @@
+% excitation_10000.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 x1=nodes(loads(ie,1),1);
 y1=nodes(loads(ie,1),2);
 x2=nodes(loads(ie,2),1);

--- a/src/FEM/excitation_20000.m
+++ b/src/FEM/excitation_20000.m
@@ -1,3 +1,38 @@
+% excitation_20000.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 x1=nodes(loads(ie,1),1);
 y1=nodes(loads(ie,1),2);
 x2=nodes(loads(ie,2),1);

--- a/src/FEM/excitation_21000.m
+++ b/src/FEM/excitation_21000.m
@@ -1,3 +1,38 @@
+% excitation_21000.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 x1=nodes(loads(ie,1),1);
 y1=nodes(loads(ie,1),2);
 x2=nodes(loads(ie,2),1);

--- a/src/FEM/excitation_50000.m
+++ b/src/FEM/excitation_50000.m
@@ -1,3 +1,38 @@
+% excitation_50000.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 x1=nodes(loads(ie,1),1);
 y1=nodes(loads(ie,1),2);
 x2=nodes(loads(ie,2),1);

--- a/src/FEM/info_FEM.m
+++ b/src/FEM/info_FEM.m
@@ -1,3 +1,38 @@
+% info_FEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 fidinfo=fopen(name_file_info,'w');
 fprintf(fidinfo,'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n');
 fprintf(fidinfo,'!!                  Output files of PLANES                   !!\n');

--- a/src/FEM/insert_temporary_matrices_elas.m
+++ b/src/FEM/insert_temporary_matrices_elas.m
@@ -1,3 +1,38 @@
+% insert_temporary_matrices_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 [i_temp,j_temp,s_temp] = find(vk0);
 ll=length(i_temp);
 i_k0_elas=[i_k0_elas(1:end);index_e(i_temp)'];

--- a/src/FEM/insert_temporary_matrices_eqf.m
+++ b/src/FEM/insert_temporary_matrices_eqf.m
@@ -1,3 +1,38 @@
+% insert_temporary_matrices_eqf.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 [i_temp,j_temp,s_temp] = find(vh);
 ll=length(i_temp);
 i_h_eqf=[i_h_eqf;index_p(i_temp)'];

--- a/src/FEM/insert_temporary_matrices_limp.m
+++ b/src/FEM/insert_temporary_matrices_limp.m
@@ -1,3 +1,38 @@
+% insert_temporary_matrices_limp.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 [i_temp,j_temp,s_temp] = find(vh);
 ll=length(i_temp);
 i_h_limp=[i_h_limp;index_p(i_temp)'];

--- a/src/FEM/insert_temporary_matrices_pem1998.m
+++ b/src/FEM/insert_temporary_matrices_pem1998.m
@@ -1,3 +1,38 @@
+% insert_temporary_matrices_pem1998.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 [i_temp,j_temp,s_temp] = find(vk0);
 ll=length(i_temp);
 i_k0_pem98=[i_k0_pem98;index_e(i_temp)'];

--- a/src/FEM/insert_temporary_matrices_pem2001.m
+++ b/src/FEM/insert_temporary_matrices_pem2001.m
@@ -1,3 +1,38 @@
+% insert_temporary_matrices_pem2001.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 [i_temp,j_temp,s_temp] = find(vk0);
 ll=length(i_temp);
 i_k0_pem01=[i_k0_pem01;index_e(i_temp)'];

--- a/src/FEM/link_FEMTMM_elas_elas.m
+++ b/src/FEM/link_FEMTMM_elas_elas.m
@@ -1,3 +1,38 @@
+% link_FEMTMM_elas_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 for ii=1:size(edges_MMT_moins,1)
     
  

--- a/src/FEM/link_FEMTMM_fluid_fluid.m
+++ b/src/FEM/link_FEMTMM_fluid_fluid.m
@@ -1,3 +1,38 @@
+% link_FEMTMM_fluid_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 for ii=1:size(edges_MMT_moins,1)
     
     node_moins=edges_MMT_moins(ii,[1 2 6]);

--- a/src/FEM/p.m
+++ b/src/FEM/p.m
@@ -1,3 +1,38 @@
+% p.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=p(node)
 
 f=3*node;

--- a/src/FEM/periodicity_condition_application.m
+++ b/src/FEM/periodicity_condition_application.m
@@ -1,3 +1,38 @@
+% periodicity_condition_application.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 %disp('Applying periodicity condtions')
 
 

--- a/src/FEM/transfer_force.m
+++ b/src/FEM/transfer_force.m
@@ -1,3 +1,38 @@
+% transfer_force.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function    F_plus=transfer_force(k_x,omega,F_moins,media)
 
 

--- a/src/FEM/transfer_unknowns.m
+++ b/src/FEM/transfer_unknowns.m
@@ -1,3 +1,38 @@
+% transfer_unknowns.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function    [Omega_plus,T_back]=transfer_unknowns(k_x,omega,Omega_moins,signe,media)
 
 

--- a/src/FEM/ux.m
+++ b/src/FEM/ux.m
@@ -1,3 +1,38 @@
+% ux.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=ux(node)
 
 f=(3*(node-1)+1);

--- a/src/FEM/uxy.m
+++ b/src/FEM/uxy.m
@@ -1,3 +1,38 @@
+% uxy.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=uxy(node)
 
 f(1:2:2*length(node))=(3*(node-1)+1);

--- a/src/FEM/uy.m
+++ b/src/FEM/uy.m
@@ -1,3 +1,38 @@
+% uy.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=uy(node)
 
 f=(3*(node-1)+2);

--- a/src/Materials/Mat_2001.m
+++ b/src/Materials/Mat_2001.m
@@ -1,3 +1,38 @@
+% Mat_2001.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.99;
 sig=11000;
 alpha=1.02000;

--- a/src/Materials/Mat_4001.m
+++ b/src/Materials/Mat_4001.m
@@ -1,3 +1,38 @@
+% Mat_4001.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.94;
 sig=40000;
 alpha=1.06000;

--- a/src/Materials/Mat_4002.m
+++ b/src/Materials/Mat_4002.m
@@ -1,3 +1,38 @@
+% Mat_4002.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.94;
 sig=100000;
 alpha=1.6000;

--- a/src/Materials/Mat_PEM_3.m
+++ b/src/Materials/Mat_PEM_3.m
@@ -1,3 +1,38 @@
+% Mat_PEM_3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.95;
 sig=42000;
 alpha=1.100;

--- a/src/Materials/Mat_PEM_4.m
+++ b/src/Materials/Mat_PEM_4.m
@@ -1,3 +1,38 @@
+% Mat_PEM_4.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.96;
 sig=10600;
 alpha=1.00;

--- a/src/Materials/Mat_PEM_5.m
+++ b/src/Materials/Mat_PEM_5.m
@@ -1,3 +1,38 @@
+% Mat_PEM_5.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.989;
 sig=8060;
 alpha=1.00;

--- a/src/Materials/Mat_elas_1.m
+++ b/src/Materials/Mat_elas_1.m
@@ -1,3 +1,38 @@
+% Mat_elas_1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 E_solide=67000000000.0;
 nu_solide=0.34E+00;
 eta_solide=0.0001;

--- a/src/Materials/Mat_elas_3.m
+++ b/src/Materials/Mat_elas_3.m
@@ -1,3 +1,38 @@
+% Mat_elas_3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 E_solide=4.968424852675948D+10;
 nu_solide=0.454021058288132D+00;
 eta_solide=0.00;

--- a/src/Materials/Mat_elas_4.m
+++ b/src/Materials/Mat_elas_4.m
@@ -1,3 +1,38 @@
+% Mat_elas_4.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 kappa_solide=3.4981e9;
 mu_solide=1.1194e9;
 eta_solide=0.00;

--- a/src/Materials/Mat_fluid_3.m
+++ b/src/Materials/Mat_fluid_3.m
@@ -1,3 +1,38 @@
+% Mat_fluid_3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.95;
 sig=42000;
 alpha=1.100;

--- a/src/Materials/PEM_3.m
+++ b/src/Materials/PEM_3.m
@@ -1,3 +1,38 @@
+% PEM_3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 phi=0.95;
 sig=42000;
 alpha=1.1000;

--- a/src/Materials/materiau_JPG.m
+++ b/src/Materials/materiau_JPG.m
@@ -1,3 +1,38 @@
+% materiau_JPG.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 clear all
 close all
 

--- a/src/Mesh/analyze_mesh.m
+++ b/src/Mesh/analyze_mesh.m
@@ -1,3 +1,38 @@
+% analyze_mesh.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 is_pw=(ismember(loads(:,4),[10 11 12]));
 is_pw_R=is_pw;
 if sum(is_pw)~=0

--- a/src/Mesh/centre_element.m
+++ b/src/Mesh/centre_element.m
@@ -1,3 +1,38 @@
+% centre_element.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=centre_element(ie)
 
 global vcor

--- a/src/Mesh/check_dirichlet.m
+++ b/src/Mesh/check_dirichlet.m
@@ -1,3 +1,38 @@
+% check_dirichlet.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 isvalidof=zeros(3*nb_nodes,1);
 
 for ie=1:nb_elements

--- a/src/Mesh/create_vector_waves.m
+++ b/src/Mesh/create_vector_waves.m
@@ -1,3 +1,38 @@
+% create_vector_waves.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/Mesh/dofdeplacement.m
+++ b/src/Mesh/dofdeplacement.m
@@ -1,3 +1,38 @@
+% dofdeplacement.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function numdof=dofdeplacement(noeud,type,direction)
 
 

--- a/src/Mesh/linearSubdivision.m
+++ b/src/Mesh/linearSubdivision.m
@@ -1,3 +1,38 @@
+% linearSubdivision.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [newVertices, newFaces] =  linearSubdivision(vertices, faces)
 % Linear subdivision for triangle meshes
 %

--- a/src/Mesh/msh2TR6.m
+++ b/src/Mesh/msh2TR6.m
@@ -1,3 +1,38 @@
+% msh2TR6.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function [nb_nodes,nb_elements,nb_edges,nodes,elements,element_label,edges,nb_media,num_media,element_num_mat,nb_interfaces,interfaces,nb_MMT,edges_MMT,nb_loads,loads,nb_dirichlets,dirichlets,nb_periodicity,periodicity]=msh2TR6(nom_fichier,tracefigure)
 
 fid=fopen(nom_fichier,'r');

--- a/src/Mesh/msl2msq.m
+++ b/src/Mesh/msl2msq.m
@@ -1,3 +1,38 @@
+% msl2msq.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 nb_noeuds_lin=size(vcor,1);
 nb_segments=3*size(kconec,1);
 nb_noeuds=size(vcor,1);

--- a/src/Mesh/parameter_element.m
+++ b/src/Mesh/parameter_element.m
@@ -1,3 +1,38 @@
+% parameter_element.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 if element_label(e_edge)==0
     c_e=c_0;

--- a/src/PLANES_Benchmark.m
+++ b/src/PLANES_Benchmark.m
@@ -1,3 +1,38 @@
+% PLANES_Benchmark.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 clear all
 close all
 clc

--- a/src/PLANES_TMM.m
+++ b/src/PLANES_TMM.m
@@ -1,3 +1,38 @@
+% PLANES_TMM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 clear all
 close all
 clc

--- a/src/PLANES_main.m
+++ b/src/PLANES_main.m
@@ -4,6 +4,41 @@
 %
 % This file is part of PLANES.
 %
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
+% PLANES_main.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
 % PLANES (Porous LAum NumErical Simulator) is a software to compute the 
 % vibroacoustic response of sound packages containing coupled 
 % acoustic/elastic/porous substructures. It is mainly based on the

--- a/src/PLANES_visualize_profiles.m
+++ b/src/PLANES_visualize_profiles.m
@@ -1,3 +1,38 @@
+% PLANES_visualize_profiles.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % File PLANES_visualize_profiles.m
 %
 % Copyright (C) 2014 Olivier DAZEL <olivier.dazel@univ-lemans.fr>

--- a/src/PW/ASplus_PEM_elas.m
+++ b/src/PW/ASplus_PEM_elas.m
@@ -1,3 +1,38 @@
+% ASplus_PEM_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_PEM_' num2str(multilayer(end).mat-1000*floor(multilayer(end).mat/1000))])

--- a/src/PW/ASplus_PEM_fluid.m
+++ b/src/PW/ASplus_PEM_fluid.m
@@ -1,3 +1,38 @@
+% ASplus_PEM_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_PEM_' num2str(multilayer(end).mat-1000*floor(multilayer(end).mat/1000))])

--- a/src/PW/ASplus_elas_fluid.m
+++ b/src/PW/ASplus_elas_fluid.m
@@ -1,3 +1,38 @@
+% ASplus_elas_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_elas_' num2str(multilayer(end).mat-1000*floor(multilayer(end).mat/1000))])

--- a/src/PW/ASplus_fluid_fluid.m
+++ b/src/PW/ASplus_fluid_fluid.m
@@ -1,3 +1,38 @@
+% ASplus_fluid_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 if multilayer(end).mat==0
     k_z_2=sqrt(k_air^2-k_x^2);

--- a/src/PW/PW_resolution.m
+++ b/src/PW/PW_resolution.m
@@ -1,3 +1,38 @@
+% PW_resolution.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 for i_f=1:abs(nb_frequencies)
     omega=2*pi*vec_freq(i_f);
     k_air=omega/air.c;

--- a/src/PW/SminusA_PEM_elas.m
+++ b/src/PW/SminusA_PEM_elas.m
@@ -1,3 +1,38 @@
+% SminusA_PEM_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_PEM_' num2str(multilayer(1).mat-1000*floor(multilayer(1).mat/1000))])

--- a/src/PW/SminusA_elas_PEM.m
+++ b/src/PW/SminusA_elas_PEM.m
@@ -1,3 +1,38 @@
+% SminusA_elas_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_PEM_' num2str(multilayer(1).mat-1000*floor(multilayer(1).mat/1000))])

--- a/src/PW/SminusA_fluid_PEM.m
+++ b/src/PW/SminusA_fluid_PEM.m
@@ -1,3 +1,38 @@
+% SminusA_fluid_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_PEM_' num2str(multilayer(1).mat-1000*floor(multilayer(1).mat/1000))])

--- a/src/PW/SminusA_fluid_elas.m
+++ b/src/PW/SminusA_fluid_elas.m
@@ -1,3 +1,38 @@
+% SminusA_fluid_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 
 eval(['Mat_elas_' num2str(multilayer(1).mat-1000*floor(multilayer(1).mat/1000))])

--- a/src/PW/SminusA_fluid_fluid.m
+++ b/src/PW/SminusA_fluid_fluid.m
@@ -1,3 +1,38 @@
+% SminusA_fluid_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 if multilayer(1).mat==0
     k_z_2=sqrt(k_air^2-k_x^2);

--- a/src/PW/State_PEM.m
+++ b/src/PW/State_PEM.m
@@ -1,3 +1,38 @@
+% State_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function M=State_PEM(k_x,delta_1,delta_2,delta_3,mu_1,mu_2,mu_3,N,A_hat,K_eq_til)
 
 

--- a/src/PW/State_elas.m
+++ b/src/PW/State_elas.m
@@ -1,3 +1,38 @@
+% State_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function M=State_elas(k_x,k_y,delta_P,delta_s,lambda,mu)
 
 

--- a/src/PW/State_fluid.m
+++ b/src/PW/State_fluid.m
@@ -1,3 +1,38 @@
+% State_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function M=State_fluid(k_x,k_z,K)
 
 k=sqrt(k_x^2+k_z^2);

--- a/src/PW/build_FEM_transfer.m
+++ b/src/PW/build_FEM_transfer.m
@@ -1,3 +1,38 @@
+% build_FEM_transfer.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function T=build_FEM_transfer(k_x,element_MMT_minus,element_MMT_plus,omega,multilayer,k_air,air)
 
 

--- a/src/PW/build_global_PW_matrices.m
+++ b/src/PW/build_global_PW_matrices.m
@@ -1,3 +1,38 @@
+% build_global_PW_matrices.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function Mat_PW=build_global_PW_matrices(k_x,omega,multilayer,termination,nb_layers,nb_amplitudes,n_w,k_air,air)
 
 

--- a/src/PW/compute_number_PW_TMM.m
+++ b/src/PW/compute_number_PW_TMM.m
@@ -1,3 +1,38 @@
+% compute_number_PW_TMM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 for ii=1:nb_layers
     switch floor(multilayer(ii).mat/1000)
         case 1

--- a/src/PW/interface_PEM_PEM.m
+++ b/src/PW/interface_PEM_PEM.m
@@ -1,3 +1,38 @@
+% interface_PEM_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 eval(['Mat_PEM_' num2str(medium_2-1000*floor(medium_1/1000))])

--- a/src/PW/interface_PEM_elas.m
+++ b/src/PW/interface_PEM_elas.m
@@ -1,3 +1,38 @@
+% interface_PEM_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 

--- a/src/PW/interface_PEM_fluid.m
+++ b/src/PW/interface_PEM_fluid.m
@@ -1,3 +1,38 @@
+% interface_PEM_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 

--- a/src/PW/interface_elas_PEM.m
+++ b/src/PW/interface_elas_PEM.m
@@ -1,3 +1,38 @@
+% interface_elas_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 eval(['Mat_elas_' num2str(medium_1-1000*floor(medium_1/1000))])

--- a/src/PW/interface_elas_elas.m
+++ b/src/PW/interface_elas_elas.m
@@ -1,3 +1,38 @@
+% interface_elas_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 eval(['Mat_elas_' num2str(medium_1-1000*floor(medium_1/1000))])

--- a/src/PW/interface_elas_fluid.m
+++ b/src/PW/interface_elas_fluid.m
@@ -1,3 +1,38 @@
+% interface_elas_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 eval(['Mat_elas_' num2str(medium_1-1000*floor(medium_1/1000))])

--- a/src/PW/interface_fluid_PEM.m
+++ b/src/PW/interface_fluid_PEM.m
@@ -1,3 +1,38 @@
+% interface_fluid_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 if medium_1==0

--- a/src/PW/interface_fluid_elas.m
+++ b/src/PW/interface_fluid_elas.m
@@ -1,3 +1,38 @@
+% interface_fluid_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 % Initialization of the State vectors in media 1 and 2
 if medium_1==0

--- a/src/PW/interface_fluid_fluid.m
+++ b/src/PW/interface_fluid_fluid.m
@@ -1,3 +1,38 @@
+% interface_fluid_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Initialization of the State vectors in media 1 and 2
 if medium_1==0
     k_z_1=sqrt(k_air^2-k_x^2);

--- a/src/PW/termination_rigid_PEM.m
+++ b/src/PW/termination_rigid_PEM.m
@@ -1,3 +1,38 @@
+% termination_rigid_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % u_z_t=0
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=SV_2(3,1)*exp(-1j*k_z_2(1)*multilayer(i_interface+1).d);

--- a/src/PW/termination_rigid_elas.m
+++ b/src/PW/termination_rigid_elas.m
@@ -1,3 +1,38 @@
+% termination_rigid_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % u_z_s=0
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=SV_2(2,1)*exp(-1j*k_z_2(1)*multilayer(i_interface+1).d);

--- a/src/PW/termination_rigid_fluid.m
+++ b/src/PW/termination_rigid_fluid.m
@@ -1,3 +1,38 @@
+% termination_rigid_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Normal displacement=1
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=SV_2(1,1)*exp(-1j*k_z_2*multilayer(i_interface+1).d);

--- a/src/PW/termination_trans_PEM.m
+++ b/src/PW/termination_trans_PEM.m
@@ -1,3 +1,38 @@
+% termination_trans_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Continuity of normal displacement
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=-SV_2(3,1)*exp(-1j*k_z_2(1)*multilayer(i_interface+1).d);

--- a/src/PW/termination_trans_elas.m
+++ b/src/PW/termination_trans_elas.m
@@ -1,3 +1,38 @@
+% termination_trans_elas.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Continuity of normal displacement
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=-SV_2(2,1)*exp(-1j*k_z_2(1)*multilayer(i_interface+1).d);

--- a/src/PW/termination_trans_fluid.m
+++ b/src/PW/termination_trans_fluid.m
@@ -1,3 +1,38 @@
+% termination_trans_fluid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Continuity of normal displacement
 number_of_eq=number_of_eq+1;
 Mat_PW(number_of_eq,dof_medium_2(1))=-SV_2(1,1)*exp(-1j*k_z_2*multilayer(i_interface+1).d);

--- a/src/Physics/air_properties_maine.m
+++ b/src/Physics/air_properties_maine.m
@@ -1,3 +1,38 @@
+% air_properties_maine.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/Physics/compute_Biot_waves.m
+++ b/src/Physics/compute_Biot_waves.m
@@ -1,3 +1,38 @@
+% compute_Biot_waves.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 delta_eq=omega.*sqrt(rho_eq_til./K_eq_til);
 delta_s_1=omega.*sqrt(rho_til./P_hat);
 delta_s_2=omega.*sqrt(rho_s_til./P_hat);

--- a/src/Physics/properties_PEM.m
+++ b/src/Physics/properties_PEM.m
@@ -1,3 +1,38 @@
+% properties_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 % Biot densities with tortuosity effects

--- a/src/Physics/properties_jca.m
+++ b/src/Physics/properties_jca.m
@@ -1,3 +1,38 @@
+% properties_jca.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 %%  Johnson et al model for rho_eq_til

--- a/src/Physics/properties_limp.m
+++ b/src/Physics/properties_limp.m
@@ -1,3 +1,38 @@
+% properties_limp.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 properties_jca
 
 rho_2=phi*rho_0;

--- a/src/Utils/create_wave_vectors.m
+++ b/src/Utils/create_wave_vectors.m
@@ -1,3 +1,38 @@
+% create_wave_vectors.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 k_air=omega/air.c;
 k_x=k_air*sin(theta);
 k_z=k_air*cos(theta);

--- a/src/Utils/display_multilayer.m
+++ b/src/Utils/display_multilayer.m
@@ -1,3 +1,38 @@
+% display_multilayer.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 function f=display_multilayer(m)
 
 for ii=1:size(m,2)

--- a/src/Utils/init_PLANES.m
+++ b/src/Utils/init_PLANES.m
@@ -1,3 +1,38 @@
+% init_PLANES.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 warning('off','MATLAB:nearlySingularMatrix')
 
 

--- a/src/Utils/init_vec_frequencies.m
+++ b/src/Utils/init_vec_frequencies.m
@@ -1,3 +1,38 @@
+% init_vec_frequencies.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 if(nb_frequencies>0)
     if nb_frequencies==1
         vec_freq=freq_min;

--- a/src/analytical_solutions/solution_FEM_TMM_pb1.m
+++ b/src/analytical_solutions/solution_FEM_TMM_pb1.m
@@ -1,3 +1,38 @@
+% solution_FEM_TMM_pb1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 % Calcul de la solution analytique
         k_parallel=k_air*sin(theta);
         k_perp=sqrt(k_eq^2-k_parallel^2);

--- a/src/plot_solution_TR6.m
+++ b/src/plot_solution_TR6.m
@@ -1,3 +1,38 @@
+% plot_solution_TR6.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 for ie=1:nb_elements

--- a/src/plots/export_fig_TR6.m
+++ b/src/plots/export_fig_TR6.m
@@ -1,3 +1,38 @@
+% export_fig_TR6.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 x=[];
 y=[];

--- a/src/plots/trace_DGM_1D_r.m
+++ b/src/plots/trace_DGM_1D_r.m
@@ -1,3 +1,38 @@
+% trace_DGM_1D_r.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 for ie=1:nb_elements

--- a/src/plots/trace_DGM_1D_x.m
+++ b/src/plots/trace_DGM_1D_x.m
@@ -1,3 +1,38 @@
+% trace_DGM_1D_x.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 for ie=1:nb_elements

--- a/src/plots/trace_DGM_1D_y.m
+++ b/src/plots/trace_DGM_1D_y.m
@@ -1,3 +1,38 @@
+% trace_DGM_1D_y.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 for ie=1:nb_elements

--- a/src/plots/trace_DGM_AIR_EF.m
+++ b/src/plots/trace_DGM_AIR_EF.m
@@ -1,3 +1,38 @@
+% trace_DGM_AIR_EF.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 for ie=1:nb_elements

--- a/src/plots/trace_DGM_pression.m
+++ b/src/plots/trace_DGM_pression.m
@@ -1,3 +1,38 @@
+% trace_DGM_pression.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/plots/trace_FEM_1D_x.m
+++ b/src/plots/trace_FEM_1D_x.m
@@ -1,3 +1,38 @@
+% trace_FEM_1D_x.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 x=[];
 y=[];

--- a/src/plots/trace_FEM_1D_y.m
+++ b/src/plots/trace_FEM_1D_y.m
@@ -1,3 +1,38 @@
+% trace_FEM_1D_y.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 x=[];
 y=[];

--- a/src/plots/trace_solution_FEM_quadratique.m
+++ b/src/plots/trace_solution_FEM_quadratique.m
@@ -1,3 +1,38 @@
+% trace_solution_FEM_quadratique.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 x=[];
 y=[];

--- a/src/plots/visu_msq.m
+++ b/src/plots/visu_msq.m
@@ -1,3 +1,38 @@
+% visu_msq.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/problems/Benchmark1.m
+++ b/src/problems/Benchmark1.m
@@ -1,3 +1,38 @@
+% Benchmark1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=60*pi/180;
 
 dx=5.5e-2;

--- a/src/problems/Benchmark1_1.m
+++ b/src/problems/Benchmark1_1.m
@@ -1,3 +1,38 @@
+% Benchmark1_1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dx=2e-2;
 dy=2e-2;
 nx=20;

--- a/src/problems/Benchmark1_2.m
+++ b/src/problems/Benchmark1_2.m
@@ -1,3 +1,38 @@
+% Benchmark1_2.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dx=2e-2;
 dy=2e-2;
 nx=10;

--- a/src/problems/Benchmark1_3.m
+++ b/src/problems/Benchmark1_3.m
@@ -1,3 +1,38 @@
+% Benchmark1_3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dx=2e-2;
 dy=2e-2;
 nx=10;

--- a/src/problems/Benchmark3.m
+++ b/src/problems/Benchmark3.m
@@ -1,3 +1,38 @@
+% Benchmark3.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=60*pi/180;
 
 dyalu=1.0e-3;

--- a/src/problems/Benchmark3_1.m
+++ b/src/problems/Benchmark3_1.m
@@ -1,3 +1,38 @@
+% Benchmark3_1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=60*pi/180;
 
 dyalu=1.0e-3;

--- a/src/problems/Benchmark4.m
+++ b/src/problems/Benchmark4.m
@@ -1,3 +1,38 @@
+% Benchmark4.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=0*pi/180;
 
 dyalu=1.0e-3;

--- a/src/problems/Benchmark5.m
+++ b/src/problems/Benchmark5.m
@@ -1,3 +1,38 @@
+% Benchmark5.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=0.1*pi/180;
 
 dyalu=1.0e-3;

--- a/src/problems/Benchmark6.m
+++ b/src/problems/Benchmark6.m
@@ -1,3 +1,38 @@
+% Benchmark6.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=60*pi/180;
 dxair=2e-2;
 dyair=5.5e-2;

--- a/src/problems/Benchmark_PoroDGM.m
+++ b/src/problems/Benchmark_PoroDGM.m
@@ -1,3 +1,38 @@
+% Benchmark_PoroDGM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 d=1;
 
 fid=fopen(nom_fichier_input_FreeFem,'w');

--- a/src/problems/Benchmark_PoroDGM.m~
+++ b/src/problems/Benchmark_PoroDGM.m~
@@ -1,3 +1,38 @@
+% Benchmark_PoroDGM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 d=1;
 
 

--- a/src/problems/FEMTMM_pb1.m
+++ b/src/problems/FEMTMM_pb1.m
@@ -1,3 +1,38 @@
+% FEMTMM_pb1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=80*pi/180;
 
 

--- a/src/problems/FEMTMM_pb1_1.m
+++ b/src/problems/FEMTMM_pb1_1.m
@@ -1,3 +1,38 @@
+% FEMTMM_pb1_1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 delta_x_MMT=0;
 delta_y_MMT=1e-2;
 dx=100e-2;

--- a/src/problems/FEMTMM_pb2_sinus.m
+++ b/src/problems/FEMTMM_pb2_sinus.m
@@ -1,3 +1,38 @@
+% FEMTMM_pb2_sinus.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 thicknessplate=1e-3;
 thicknessporous=1e-3;

--- a/src/problems/FEM_TMM_pb2.m
+++ b/src/problems/FEM_TMM_pb2.m
@@ -1,3 +1,38 @@
+% FEM_TMM_pb2.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 theta=60*pi/180;
 
 dyalu=1.0e-3;

--- a/src/problems/Manip_TW_rigid.m
+++ b/src/problems/Manip_TW_rigid.m
@@ -1,3 +1,38 @@
+% Manip_TW_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dxair=2e-2;
 dyair=2e-2;
 nx=5;

--- a/src/problems/TW.m
+++ b/src/problems/TW.m
@@ -1,3 +1,38 @@
+% TW.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 period=60e-3;
 thicknessporous=5.5e-2;
 labelporous=5005;

--- a/src/problems/air_PEM.m
+++ b/src/problems/air_PEM.m
@@ -1,3 +1,38 @@
+% air_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 d_air=1;
 d_PEM=1;
 n_air=1;

--- a/src/problems/air_PML.m
+++ b/src/problems/air_PML.m
@@ -1,3 +1,38 @@
+% air_PML.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 d_air=1;
 d_pml=1;
 n_air=3;

--- a/src/problems/rad_cylinder.m
+++ b/src/problems/rad_cylinder.m
@@ -1,3 +1,38 @@
+% rad_cylinder.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 lx=0.2;
 ly=0.2;
 ax=0.2;

--- a/src/problems/sandwich.m
+++ b/src/problems/sandwich.m
@@ -1,3 +1,38 @@
+% sandwich.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 period=10e-2;
 thicknessplate=5e-3;
 thicknessporous=2e-2;

--- a/src/problems/sandwich_1.m
+++ b/src/problems/sandwich_1.m
@@ -1,3 +1,38 @@
+% sandwich_1.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 period=50e-2;
 thicknessplate=1e-3;
 thicknessporous=2e-2;

--- a/src/problems/sandwich_2.m
+++ b/src/problems/sandwich_2.m
@@ -1,3 +1,38 @@
+% sandwich_2.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 period=50e-2;
 thicknessplate=1e-3;
 thicknessporous=2e-2;

--- a/src/problems/tranche_EF_rigid.m
+++ b/src/problems/tranche_EF_rigid.m
@@ -1,3 +1,38 @@
+% tranche_EF_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dxair=5e-1;
 dyair=2e-1;
 nx=5;

--- a/src/problems/tranche_EF_transmission.m
+++ b/src/problems/tranche_EF_transmission.m
@@ -1,3 +1,38 @@
+% tranche_EF_transmission.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dxair=50e-2;
 dyair=20e-2;
 nx=25;

--- a/src/problems/tranche_air_rigid.m
+++ b/src/problems/tranche_air_rigid.m
@@ -1,3 +1,38 @@
+% tranche_air_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dxair=2e-1;
 dyair=0.2e-1;
 nx=20;

--- a/src/problems/tranche_air_transmission.m
+++ b/src/problems/tranche_air_transmission.m
@@ -1,3 +1,38 @@
+% tranche_air_transmission.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dxair=5e-2;
 dyair=2e-2;
 nx=8;

--- a/src/problems/tranche_alu_rigid.m
+++ b/src/problems/tranche_alu_rigid.m
@@ -1,3 +1,38 @@
+% tranche_alu_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dyalu=1.2e-3;
 nyalu=10;
 dyair=1e-2;

--- a/src/problems/tranche_alu_rigid.m~
+++ b/src/problems/tranche_alu_rigid.m~
@@ -1,3 +1,38 @@
+% tranche_alu_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 dyalu=1.2e-3;
 nyalu=3;
 dyair=1e-2;

--- a/src/problems/tranche_alu_transmission.m
+++ b/src/problems/tranche_alu_transmission.m
@@ -1,3 +1,38 @@
+% tranche_alu_transmission.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 dyalu=1.0e-3;
 

--- a/src/validation/validation_AIR_EF.m
+++ b/src/validation/validation_AIR_EF.m
@@ -1,3 +1,38 @@
+% validation_AIR_EF.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 calcul_propriete;
 calcul_theorique;
 

--- a/src/validation/validation_AIR_PEM.m
+++ b/src/validation/validation_AIR_PEM.m
@@ -1,3 +1,38 @@
+% validation_AIR_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 d_y=d_PEM;

--- a/src/validation/validation_AIR_PML.m
+++ b/src/validation/validation_AIR_PML.m
@@ -1,3 +1,38 @@
+% validation_AIR_PML.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 tau_x=exp(j*pi/4);

--- a/src/validation/validation_AIR_PML.m~
+++ b/src/validation/validation_AIR_PML.m~
@@ -1,3 +1,38 @@
+% validation_AIR_PML.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 calcul_propriete;
 calcul_theorique;
 

--- a/src/validation/validation_PEM.m
+++ b/src/validation/validation_PEM.m
@@ -1,3 +1,38 @@
+% validation_PEM.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/validation/validation_PEM_1998.m
+++ b/src/validation/validation_PEM_1998.m
@@ -1,3 +1,38 @@
+% validation_PEM_1998.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/validation/validation_PEM_2001.m
+++ b/src/validation/validation_PEM_2001.m
@@ -1,3 +1,38 @@
+% validation_PEM_2001.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 

--- a/src/validation/validation_air_alu.m
+++ b/src/validation/validation_air_alu.m
@@ -1,3 +1,38 @@
+% validation_air_alu.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 
 
 d_y=d_PEM;

--- a/src/validation/validation_tranche_alu_rigid.m
+++ b/src/validation/validation_tranche_alu_rigid.m
@@ -1,3 +1,38 @@
+% validation_tranche_alu_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 k_0=omega/c_0;
 
 % Dans l'alu

--- a/src/validation/validation_tranche_alu_rigid.m~
+++ b/src/validation/validation_tranche_alu_rigid.m~
@@ -1,3 +1,38 @@
+% validation_tranche_alu_rigid.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 k_0=omega/c_0;
 
 % Dans l'alu

--- a/src/validation/validation_tranche_alu_transmission.m
+++ b/src/validation/validation_tranche_alu_transmission.m
@@ -1,3 +1,38 @@
+% validation_tranche_alu_transmission.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 k_0=omega/c_0;
 
 % Dans l'alu

--- a/src/validation/validation_tranche_alu_transmission.m~
+++ b/src/validation/validation_tranche_alu_transmission.m~
@@ -1,3 +1,38 @@
+% validation_tranche_alu_transmission.m
+%
+% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+% https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+% http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
 k_0=omega/c_0;
 
 % Dans l'alu


### PR DESCRIPTION
The useful script : 

```
#! /bin/bash
#
# add_header.sh
#
# Copyright © 2014 Mathieu Gaborit (matael) <mathieu@matael.org>
#
#
# Distributed under WTFPL terms
#
#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
#                    Version 2, December 2004
#
# Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
#
# Everyone is permitted to copy and distribute verbatim or modified
# copies of this license document, and changing it is allowed as long
# as the name is changed.
#
#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
#   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
#
#  0. You just DO WHAT THE FUCK YOU WANT TO.
#


generic_header="%\n% Copyright (C) 2014 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >\n%\n% This file is part of PLANES.\n%\n% PLANES (Porous LAum NumErical Simulator) is a software to compute the\n% vibroacoustic response of sound packages containing coupled\n% acoustic/elastic/porous substructures.  It is mainly based on the\n% Finite-Element Method and some numerical methods developped at\n% LAUM (http://laum.univ-lemans.fr).\n%\n% You can download the latest version of PLANES at\n%                 https://github.com/OlivierDAZEL/PLANES\n% or find more details on Olivier's webpage\n%                 http://perso.univ-lemans.fr/~odazel/\n%\n% For any questions or if you want to\n% contribute to this project, contact Olivier.\n%\n% PLANES is free software: you can redistribute it and/or modify\n% it under the terms of the GNU General Public License as published by\n% the Free Software Foundation, either version 3 of the License, or\n% (at your option) any later version.\n%\n% This program is distributed in the hope that it will be useful,\n% but WITHOUT ANY WARRANTY; without even the implied warranty of\n% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n% GNU General Public License for more details.\n%\n% You should have received a copy of the GNU General Public License\n% along with this program.  If not, see <http://www.gnu.org/licenses/>.\n%%\n\n"


tmpfile="content_tmp"
orig=$PWD
for dir in $(find ./ -type d); do
    cd $dir
    for f in *.m*; do
        if [[ "${f:$((${#str}-1)):1}" == "~" ]]; then
            filename="${f::-1}"
        else
            filename="$f"
        fi
        echo "Working on $dir/$f"
        cp $f $tmpfile
        echo "% $filename" > $f
        echo -e $generic_header >> $f
        cat $tmpfile>> $f
    done
    rm $tmpfile
    cd $orig
done
```
