### PR TITLE
Separate project dirs from codebase. They now can be stored anywhere.

### DIFF
--- a/src/Main/PLANES.m
+++ b/src/Main/PLANES.m
@@ -1,0 +1,98 @@
+% PLANES_main.m
+%
+% Copyright (C) 2015 < Olivier DAZEL <olivier.dazel@univ-lemans.fr> >
+%
+% This file is part of PLANES.
+%
+% PLANES (Porous LAum NumErical Simulator) is a software to compute the
+% vibroacoustic response of sound packages containing coupled
+% acoustic/elastic/porous substructures. It is mainly based on the
+% Finite-Element Method and some numerical methods developped at
+% LAUM (http://laum.univ-lemans.fr).
+%
+% You can download the latest version of PLANES at
+%                 https://github.com/OlivierDAZEL/PLANES
+% or find more details on Olivier's webpage
+%                  http://perso.univ-lemans.fr/~odazel/
+%
+% For any questions or if you want to
+% contribute to this project, contact Olivier.
+%
+% PLANES is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%%
+
+
+function PLANES(projectdir, expnb)
+	close all;
+	clc;
+
+	% add project path and load informations
+	name.project_directory=projectdir;
+	% add subpaths
+	paths={'','/Plots','/Physics','/Solutions','/Validation'};
+	for i=1:length(paths)
+		if exist([name.project_directory paths{i}])==7
+			addpath([name.project_directory paths{i}]);
+		end
+	end
+	clearvars paths
+
+	project_info % load project data from project dir
+
+	if nargin<2
+		if exist('project.num')==0
+			project.num=0;
+		end
+	else
+		project.num=expnb;
+	end
+
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	%% Initialization of PLANES
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	PLANES_init
+	air_properties_maine
+	init_vec_frequencies
+
+
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	%% Creation and importation of the mesh
+	% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+	eval([name.project_full]);
+
+	%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+	PLANES_preprocess
+
+	if profiles.mesh
+		display_mesh
+	end
+
+
+	if nb.dof_FEM>0
+		EF_global_build
+	end
+
+	PLANES_resolution
+
+	PLANES_info
+
+	%Analytical solution (if exists)
+	if ((exist(name.solution)==2)&&(profiles.on~=0))
+		eval('eval(name.solution)')
+	end
+
+end
+

--- a/src/Main/PLANES_init.m
+++ b/src/Main/PLANES_init.m
@@ -38,8 +38,13 @@ eval(['addpath(' list_path ');'])
 
 warning('off','MATLAB:nearlySingularMatrix')
 
+if exist('name')~=1
+	name.project_directory=['../../Projects/' project.name '/'];
+end
 
-name.project_directory=['../../Projects/' project.name '/'];
+if name.project_directory(end)~='/'
+	name.project_directory = [name.project_directory '/'];
+end
 
 if project.num==0
     name.file=[name.project_directory project.name];

--- a/src/Main/postprocess_solution.m
+++ b/src/Main/postprocess_solution.m
@@ -79,6 +79,12 @@ if profiles.custom~=0
     eval(['plot_sol_TR6_custom_' , num2str(profiles.custom)]);
 end
 
+% custom plots
+if isfield(profiles, 'custom_plots') && length(profiles.custom_plots)~=0
+	for i=1:length(profiles.custom_plots)
+		eval(profiles.custom_plots{i});
+	end
+end
 
 
 clear('sol')


### PR DESCRIPTION
The new possible calling method is :

cd 'src/Main';
PLANES('relative/path/to/project/', project_num)

A project_info.m file stored within the project dir contains all relevant informations.
Documentation on this feature will be provided soon. This commit doesn't break the old behaviour.