### PR TITLE
Separated Projects : Typo Fix & Example

### DIFF
--- a/Example/Example_1.edp
+++ b/Example/Example_1.edp
@@ -1,0 +1,32 @@
+string fileoutput;
+real lx; 
+real ly;
+int nx;
+int ny;
+
+ifstream entree("FF.inp");
+entree >> fileoutput;
+entree >> lx;
+entree >> ly;
+entree >> nx;
+entree >> ny;
+
+real xA=0,yA=0;
+real xB=lx,yB=0;
+real xC=lx,yC=ly;
+real xD=0,yD=ly;
+
+
+
+
+border AB(t=0,1){ x=xA+(xB-xA)*t; y=yA+(yB-yA)*t;label=3;}
+border BC(t=0,1){ x=xB+(xC-xB)*t; y=yB+(yC-yB)*t;label=1;}
+border CD(t=0,1){ x=xC+(xD-xC)*t; y=yC;label=1;}
+border DA(t=0,1){ x=xD+(xA-xD)*t; y=yD+(yA-yD)*t;label=1;}
+
+
+mesh Thtube=buildmesh (AB(nx)+BC(ny)+CD(nx)+DA(ny),fixeborder=1);
+
+savemesh(Thtube,fileoutput);
+
+plot(Thtube);

--- a/Example/Example_1.m
+++ b/Example/Example_1.m
@@ -1,0 +1,31 @@
+model_data.lx=1;
+model_data.ly=1;
+model_data.nx=2;
+model_data.ny=ceil(model_data.nx*model_data.ly/model_data.lx);
+
+
+
+%solve.TR6=1;
+
+fid=fopen(name.file_input_FreeFem,'w');
+fprintf(fid,'%s\n',name.file_msh);
+fprintf(fid,'%12.8f\n',model_data.lx);
+fprintf(fid,'%12.8f\n',model_data.ly);
+fprintf(fid,'%d\n',model_data.nx);
+fprintf(fid,'%d\n',model_data.ny);
+fclose(fid);
+
+% Call to FreeFem++ to create a msh File
+system(['/usr/local/bin/FreeFem++ ' name.file_edp]);
+
+
+%Importation of the msh File
+
+disp(name.file_msh)
+[nb,nodes,elem,edge_msh]=msh_import(name.file_msh);
+
+% All the elements are TR6
+elem.model=1*ones(nb.elements,1);
+
+
+

--- a/Example/project_info.m
+++ b/Example/project_info.m
@@ -1,0 +1,21 @@
+project.name='Example';
+project.num=1;
+
+% Number of frequencies
+% If the number is negative then a logscale is chosen
+% If the number is equal to 1, then the frequency is equal to freq_min
+frequency.nb=1;
+frequency.min=100;
+frequency.max=750;
+
+profiles.mesh=1;
+profiles.solution=0;
+profiles.x=0;
+profiles.y=0;
+profiles.map=1;
+profiles.custom=0;
+profiles.on=profiles.x+profiles.y+profiles.map+profiles.custom;
+profiles.custom_plots = {};
+
+export.nrj=0;
+export.profiles=0;

--- a/src/Main/PLANES.m
+++ b/src/Main/PLANES.m
@@ -51,7 +51,7 @@ function PLANES(projectdir, expnb)
 	project_info % load project data from project dir
 
 	if nargin<2
-		if exist('project.num')==0
+		if exist('project.num')~=0
 			project.num=0;
 		end
 	else


### PR DESCRIPTION
Fix typo in the write of a condition that was systematically leading to an 0 project.num. Also add an example project (using the separation parad.).