### PR TITLE
MATLab compatibility fixes

### DIFF
--- a/src/Main/PLANES.m
+++ b/src/Main/PLANES.m
@@ -50,7 +50,7 @@ function PLANES(projectname, expnb, data_model, frequency, name)
 project.name=projectname;
 project.num=expnb;
 
-if !isfield(data_model, 'verbosity')
+if ~isfield(data_model, 'verbosity')
     data_model.verbosity = 0;
 end
 

--- a/src/Main/PLANES_init.m
+++ b/src/Main/PLANES_init.m
@@ -73,7 +73,7 @@ set(0,'DefaultAxeslinewidth',2);
 
 air_properties_JPG
 
-if !isfield(data_model, 'ngauss')
+if ~isfield(data_model, 'ngauss')
 	data_model.ngauss = 10;
 end
 Gauss_points=compute_GaussLegendre_points(data_model.ngauss);

--- a/src/Utils/is_octave.m
+++ b/src/Utils/is_octave.m
@@ -1,0 +1,10 @@
+% Detect if running MATLab or Octave
+% From http://wiki.octave.org/Compatibility
+
+function r = is_octave()
+  persistent x;
+  if (isempty (x))
+    x = exist ('OCTAVE_VERSION', 'builtin');
+  end
+  r = x;
+end

--- a/src/Utils/logger.m
+++ b/src/Utils/logger.m
@@ -42,10 +42,18 @@ function logger(verbosity, level, section, msg, wait)
 
 	if level==0
 		prefix = '=>';
-		out = stdout;
+		if (is_octave)
+			out = stdout;
+		else
+			out = 1;
+		end
 	else
 		prefix = '[log]';
-		out = stderr;
+		if (is_octave)
+			out = stderr;
+		else
+			out = 2;
+		end
 	end
 	if verbosity>=level
 		fprintf(out, '%s %s: %s\n', prefix, section, msg);


### PR DESCRIPTION
Due to my Octave-based workflow, some octave-specific constructions made their way into the code. Particularly, `!` instead of `~` was used as a boolean NOT and the pseudo filehandles `stderr` & `stdout` were used (they do not exist in Matlab).